### PR TITLE
Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,8 @@ COPY seeddata/*.csv /app/src/main/resources/config/liquibase/fake-data/
 # Install all the packages
 RUN ./mvnw package
 
+# Add ngrok-free.app to origin whitelist
+RUN sed -i "s|allowed-origin-patterns: .*$|allowed-origin-patterns: 'https://*.ngrok-free.app/'|g" /app/src/main/resources/config/application-dev.yml
+
 EXPOSE 8080
 CMD ./mvnw

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,29 @@
-FROM jhipster/jhipster:latest
+FROM jhipster/jhipster:v8.1.0
 
 WORKDIR /app
 COPY *.jdl /app
 
+# Generate a git repo to make jhipster happy
 RUN \
-    npx jhipster jdl --no-insight application.jdl && \
-    npx jhipster jdl --no-insight model.jdl
+    git config --global user.email "you@example.com" && \
+    git config --global user.name "Your Name" && \
+    git init
 
+# Generate the code
+RUN \
+    npx jhipster jdl --no-insight --force application.jdl && \
+    npx jhipster jdl --no-insight --force model.jdl
+
+# Copy the initial data
+RUN \
+    rm -rf /app/src/main/resources/config/liquibase/fake-data/car.csv && \
+    rm -rf /app/src/main/resources/config/liquibase/fake-data/customer.csv && \
+    rm -rf /app/src/main/resources/config/liquibase/fake-data/employee.csv && \
+    rm -rf /app/src/main/resources/config/liquibase/fake-data/location.csv
 COPY seeddata/*.csv /app/src/main/resources/config/liquibase/fake-data/
+
+# Install all the packages
+RUN ./mvnw package
 
 EXPOSE 8080
 CMD ./mvnw

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM jhipster/jhipster:latest
+
+WORKDIR /app
+COPY *.jdl /app
+
+RUN \
+    npx jhipster jdl --no-insight application.jdl && \
+    npx jhipster jdl --no-insight model.jdl
+
+COPY seeddata/*.csv /app/src/main/resources/config/liquibase/fake-data/
+
+EXPOSE 8080
+CMD ./mvnw

--- a/README.md
+++ b/README.md
@@ -70,18 +70,19 @@ Het is ook mogelijk om het project in een docker container op te starten, het vo
 
 ### De mad-backend applicatie direct in een container draaien (beste methode)
 
-Dit download een image die al is gemaakt en alleen de benodigde dingen heeft.
+Deze image is al gemaakt, en bevat alle benodigde dingen.
 
 ```bash
 docker pull ghcr.io/wjtje/mad-backend:latest
 docker run -it -p 8080:8080 ghcr.io/wjtje/mad-backend:latest
 ```
 
-### Jhipster compleet in een container draaien
+### Zelf de jhipster container maken
 
 ```bash
 docker build -t mad-backend:latest .
-docker run -it -p 8080:8080 mad-backend:latest
+docker run -it -p 8080:8080 mad-backend:latest -- /bin/bash
+./mvnw package jib:build -Djib.to.image=ghcr.io/USERNAME/mad-backend:latest -Djib.to.auth.username=USERNAME -Djib.to.auth.password=PERSONAL_ACCESS_TOKEN
 ```
 
 *Let op:* Het is de bedoeling dat iedereen met dezelfde backend werkt. Mocht je ideeën, aanvullingen of verbeteringen hebben voor deze backend, start dan een discussie op github of doe een pull request.

--- a/README.md
+++ b/README.md
@@ -66,8 +66,18 @@ ngrok http 8080 --domain ladybird-sharp-alpaca.ngrok-free.app
 ```
 
 ## Docker
-Het is ook mogelijk om het project in een docker container op te starten, het voordeel hiervan is dat je niet locaal Java en Jhipster hoeft te hebben.
-Het bouwen van de image kan een paar (5-10) minuten duren, dus heb geduld. Je moet nog wel zelf Ngrok installeren.
+Het is ook mogelijk om het project in een docker container op te starten, het voordeel hiervan is dat je niet locaal Java en Jhipster hoeft te hebben. Hiervoor hebt je twee opties.
+
+### De mad-backend applicatie direct in een container draaien (beste methode)
+
+Dit download een image die al is gemaakt en alleen de benodigde dingen heeft.
+
+```bash
+docker pull ghcr.io/wjtje/mad-backend:latest
+docker run -it -p 8080:8080 ghcr.io/wjtje/mad-backend:latest
+```
+
+### Jhipster compleet in een container draaien
 
 ```bash
 docker build -t mad-backend:latest .

--- a/README.md
+++ b/README.md
@@ -66,3 +66,11 @@ ngrok http 8080 --domain ladybird-sharp-alpaca.ngrok-free.app
 ```
 
 *Let op:* Het is de bedoeling dat iedereen met dezelfde backend werkt. Mocht je ideeën, aanvullingen of verbeteringen hebben voor deze backend, start dan een discussie op github of doe een pull request.
+
+## Docker
+Het is ook mogelijk om het project in een docker container op te starten, het voordeel hiervan is dat je niet locaal Java en Jhipster hoeft te hebben.
+
+```bash
+docker build -t mad-backend:latest .
+docker run -it -p 8080:8080 mad-backend:latest
+```

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> INFO: Gebruik de nieuwe mad-backend-generated
+
 # Inleiding
 
 Dit document beschrijft de minimale stappen die nodig zijn om het backend deel woor de course *Mobile Application Development* draaiend te krijgen.

--- a/README.md
+++ b/README.md
@@ -65,12 +65,13 @@ De volgende stappen beschrijven hoe je ngrok aan de praat kan krijgen:
 ngrok http 8080 --domain ladybird-sharp-alpaca.ngrok-free.app
 ```
 
-*Let op:* Het is de bedoeling dat iedereen met dezelfde backend werkt. Mocht je ideeën, aanvullingen of verbeteringen hebben voor deze backend, start dan een discussie op github of doe een pull request.
-
 ## Docker
 Het is ook mogelijk om het project in een docker container op te starten, het voordeel hiervan is dat je niet locaal Java en Jhipster hoeft te hebben.
+Het bouwen van de image kan een paar (5-10) minuten duren, dus heb geduld. Je moet nog wel zelf Ngrok installeren.
 
 ```bash
 docker build -t mad-backend:latest .
 docker run -it -p 8080:8080 mad-backend:latest
 ```
+
+*Let op:* Het is de bedoeling dat iedereen met dezelfde backend werkt. Mocht je ideeën, aanvullingen of verbeteringen hebben voor deze backend, start dan een discussie op github of doe een pull request.


### PR DESCRIPTION
Deze PR voegt een docker image toe dat je het makkelijker kan draaien op verschillende apparaten. Als je deze PR toevoegt moet je eventjes de 'Zelf de jhipster container maken' volgen om de image te maken en uploaden naar github packages. Daarna kan je de readme weer aanpassen dat het wijst naar deze repo.

Ook moet het nog duidelijk worden hoe je tijdens het draaien van de container de database in een docker volume kan hebben dat je data persistent is.